### PR TITLE
Bugfix/fix heroku nonbinding port issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,10 @@ jspm_packages
 .idea/
 *.iml
 
+# coverty files
+cov-int/
+cov-int-project.tgz
+
 development.sh
 test.sh
 

--- a/lib/facebook.js
+++ b/lib/facebook.js
@@ -2,7 +2,7 @@
 
 const FB = require('fbgraph');
 FB.setVersion(process.env.FB_GRAPH_API_VERSION || '2.8');
-FB.setAccessToken(process.env.FB_GRAPH_API_TOKEN)
+FB.setAccessToken(process.env.FB_GRAPH_API_TOKEN);
 
 /**
  * Example:
@@ -10,4 +10,4 @@ FB.setAccessToken(process.env.FB_GRAPH_API_TOKEN)
  */
 module.exports.getEvents = function(callback) {
   FB.get('resistance-calendar/events', callback);
-}
+};

--- a/routes/handlers/facebook.js
+++ b/routes/handlers/facebook.js
@@ -1,14 +1,9 @@
 const Facebook = require('../../lib/facebook');
 
 module.exports.events = {
-    handler: function (request, reply) {
-        Facebook.getEvents(function (err, res) {
-            return reply(res);
-        });
-    },
-    plugins: {
-        hal: {
-            api: 'osdi:events'
-        }
-    }
+  handler: function (request, reply) {
+    Facebook.getEvents(function(err, res) {
+      return reply(res).type('application/json');
+    });
+  }
 };

--- a/routes/handlers/facebook.js
+++ b/routes/handlers/facebook.js
@@ -1,9 +1,14 @@
 const Facebook = require('../../lib/facebook');
 
 module.exports.events = {
-  handler: function (request, reply) {
-    Facebook.getEvents(function(err, res) {
-      return reply(res).type('application/json');
-    });
-  }
+    handler: function (request, reply) {
+        Facebook.getEvents(function (err, res) {
+            return reply(res);
+        });
+    },
+    plugins: {
+        hal: {
+            api: 'osdi:events'
+        }
+    }
 };

--- a/server.js
+++ b/server.js
@@ -8,10 +8,9 @@ Db = require('./lib/database');
 // Create a server with a host and port
 const server = new Hapi.Server();
 server.connection({
-    host: 'localhost',
     port: process.env.PORT || 8000
 });
-//
+
 // Add the route
 server.route({
     method: 'GET',

--- a/server.js
+++ b/server.js
@@ -11,7 +11,7 @@ server.connection({
     host: 'localhost',
     port: process.env.PORT || 8000
 });
-
+//
 // Add the route
 server.route({
     method: 'GET',


### PR DESCRIPTION
This should fix the issue with Heroku not working.  The problem is from using "localhost" in the host setting for server.js.  That binds not only to the given port but to that host/ip which ends up being 127.0.0.1.  The app won't respond to anything outside of the local machine.

I don't think this will break local dev environments because it should just bind to your machine's ip and work just fine both from localhost and not from localhost.  You might need to use your machines's ip instead of localhost.  If this is really annoying or doesn't work we can try to put in something to detect if we're running on heroku and simply flip off the host setting otherwise leave it set to localhost.