### PR TITLE
Cache facebook/events

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,3 +1,3 @@
 module.exports = {
-  mongoUri: process.env.MONGODB_URI
+  mongoUri: process.env.MONGODB_URI | 'mongodb://127.0.0.1:27017'
 };

--- a/package.json
+++ b/package.json
@@ -21,10 +21,12 @@
   "homepage": "https://github.com/ResistanceCalendar/resistance-calendar-api#readme",
   "dependencies": {
     "bluebird": "^3.5.0",
+    "catbox-mongodb": "3.0.1",
     "fbgraph": "^1.4.1",
     "hapi": "^16.1.0",
     "joi": "^10.2.2",
     "lodash": "^4.17.4",
+    "moment": "2.18.0",
     "mongodb": "^1.4",
     "mongoose": "^4.8.6"
   },

--- a/routes/handlers/facebook.js
+++ b/routes/handlers/facebook.js
@@ -1,24 +1,25 @@
 const Facebook = require('../../lib/facebook');
 
-module.exports.events = {
-  handler: function (request, reply) {
-    Facebook.getOSDIEvents(function (err, osdiEvents) {
-      if (err) {
-        console.log('Error: ' + request + '\n' + err);
-        reply(err);
-        return;
+/**
+ * Example:
+ *  Facebook.doGetEvents(function (err, result) {...})
+ */
+module.exports.events = function (next) {
+  Facebook.getOSDIEvents(function (err, osdiEvents) {
+    if (err) {
+      console.log('Error: ' + JSON.stringify(err));
+      next(err);
+      return;
+    }
+    const response = {
+      total_pages: 1,
+      per_page: osdiEvents.length,
+      page: 1,
+      total_records: osdiEvents.length,
+      _embedded: {
+        'osdi:events': osdiEvents
       }
-      const response = {
-        total_pages: 1,
-        per_page: osdiEvents.length,
-        page: 1,
-        total_records: osdiEvents.length,
-        _embedded: {
-          'osdi:events': osdiEvents
-        }
-      };
-      return reply(response)
-        .type('application/json');
-    });
-  }
+    };
+    next(null, response);
+  });
 };

--- a/routes/index.js
+++ b/routes/index.js
@@ -1,10 +1,33 @@
 const Facebook = require('./handlers/facebook');
 const Event = require('./handlers/event');
 const Location = require('./handlers/location');
+const moment = require('moment');
+
+/**
+ * Setting up caching via help from the following article:
+ *   http://vawks.com/blog/2014/03/15/caching-with-hapi/
+ *
+ * All times in ms:
+ *  expiresIn - relative expiration since the item was saved in the cache
+ *  staleIn - mark an item stored in cache as stale and attempt to regenerate
+ *  staleTimeout - wait before returning a stale value while generateFunc is
+ *                 generating a fresh value.
+ *  generateTimeout - wait before returning a timeout error when the
+ *                    generateFunc function takes too long to return a value
+ */
 
 exports.register = (plugin, options, next) => {
+  plugin.method('getFacebookEvents', Facebook.events, {
+    cache: {
+      expiresIn: moment.duration(5, 'minute').asMilliseconds(),
+      staleIn: moment.duration(1, 'minute').asMilliseconds(),
+      staleTimeout: 100,
+      generateTimeout: moment.duration(2, 'seconds').asMilliseconds()
+    }
+  });
+
   plugin.route([
-    { method: 'GET', path: '/facebook/events', config: Facebook.events },
+    createRoute('GET', '/facebook/events', plugin.methods.getFacebookEvents),
     { method: 'POST', path: '/events', config: Event.create },
     { method: 'POST', path: '/location', config: Location.create }
   ]);
@@ -13,4 +36,16 @@ exports.register = (plugin, options, next) => {
 
 exports.register.attributes = {
   name: 'api'
+};
+
+const createRoute = function (method, path, serverMethod) {
+  return {
+    method: method,
+    path: path,
+    handler: function (request, reply) {
+      serverMethod(function (error, result) {
+        reply(error || result);
+      });
+    }
+  };
 };

--- a/server.js
+++ b/server.js
@@ -1,10 +1,19 @@
 'use strict';
 
+const config = require('./config');
+
 const Hapi = require('hapi');
 require('./lib/database'); // contains side effect for initializing database
 
 // Create a server with a host and port
-const server = new Hapi.Server();
+const server = new Hapi.Server({
+  cache: [{
+    name: 'mongoCache',
+    engine: require('catbox-mongodb'),
+    host: config.mongoUri,
+    partition: 'cache'
+  }]
+});
 server.connection({
   port: process.env.PORT || 8000
 });


### PR DESCRIPTION
Add catbox-mongodb to avoid making repeated facebook calls to cap request rates and reduce response latencies.