### PR TITLE
Regnerate MONGODB_URI on deploy

### DIFF
--- a/app.json
+++ b/app.json
@@ -9,9 +9,6 @@
     "FB_GRAPH_API_VERSION": {
       "required": true
     },
-    "MONGODB_URI": {
-      "required": true
-    },
     "PAPERTRAIL_API_TOKEN": {
       "required": true
     }


### PR DESCRIPTION
Simply leaving out the variable will create a new mongo db instance on env variable for staging / review app deployments