### PR TITLE
Location based search

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Queries are intended to comply with the [ODATA standard](http://docs.oasis-open.
 * Filter by nested property (postal_code and locality/city):
  * [https://resistance-calendar.herokuapp.com/v1/events?$filter=location/postal_code eq '22980'](https://resistance-calendar.herokuapp.com/v1/events?$filter=location/postal_code%20eq%20'22980')
  * [https://resistance-calendar.herokuapp.com/v1/events?$filter=contains(location/locality, 'Savannah')](https://resistance-calendar.herokuapp.com/v1/events?$filter=contains%28location/locality,%20'Savannah'%29)
+* Filtering by location is based on coordinates (longitude, latitude) and distance in meters
+ * [http://resistance-calendar.herokuapp.com/v1/events?distance_coords=[-98.435508,29.516496]&distance_max=10000](http://resistance-calendar.herokuapp.com/v1/events?distance_coords=[-98.435508,29.516496]&distance_max=10000)
 
 ### Ordering
 

--- a/lib/facebook.js
+++ b/lib/facebook.js
@@ -70,6 +70,8 @@ module.exports.toOSDIEvent = function (facebookEvent) {
       region: facebookEventLocation.state,
       postal_code: facebookEventLocation.zip,
       location: {
+        longitude: facebookEventLocation.longitude,
+        latitude: facebookEventLocation.latitude,
         type: 'Point',
         coordinates: [
           facebookEventLocation.longitude,

--- a/models/osdi/event.js
+++ b/models/osdi/event.js
@@ -43,10 +43,13 @@ const EventSchema = new mongoose.Schema({
       country: { type: String },
       language: { type: String },
       location: {
+        latitude: { type: Number },
+        longitude: { type: Number },
+        accuracy: {type: String, enum: ['Rooftop', 'Approximate']},
+        // The following two fields are for 2dsphere querying and not OSDI
+        // specific
         type: { type: String },
-        // coordinate are [latitude, longitude]
-        coordinates: [Number],
-        accuracy: {type: String, enum: ['Rooftop', 'Approximate']}
+        coordinates: [Number]
       }
     },
     required: false

--- a/routes/handlers/event.js
+++ b/routes/handlers/event.js
@@ -1,6 +1,6 @@
 const Event = require('../../models/osdi/event');
 const Joi = require('joi');
-const lodash = require('lodash');
+const _ = require('lodash');
 const ODATA = require('../../lib/odata');
 
 const OPTS_SCHEMA = Joi.object().keys({
@@ -9,13 +9,19 @@ const OPTS_SCHEMA = Joi.object().keys({
   $filter: Joi.string(),
   $orderby: Joi.string(),
   $top: Joi.number().integer(),
-  $inlinecount: Joi.number().integer()
+  $inlinecount: Joi.number().integer(),
+
+  // No ODATA standard for geometric search
+  distance_coords: Joi.array().items(Joi.number().required(), Joi.number().required()),
+  distance_max: Joi.number().integer()
 });
 
-exports.get = function (opts, next) {
+const get = function (opts, next) {
   Joi.validate(opts.query, OPTS_SCHEMA, function (err, query) {
     if (err) handleError(next, 'validating', err);
-    const filter = ODATA.createFilter(query.$filter);
+    const searchFilter = ODATA.createFilter(query.$filter);
+    const distanceFilter = createProximityFilter('location.location', query.distance_coords, query.distance_max);
+    const filter = _.merge(searchFilter, distanceFilter);
     const orderBy = ODATA.createOrderBy(query.$orderby);
     console.log(`mongo db filter = ${JSON.stringify(filter)} orderBy = ${JSON.stringify(orderBy)}`);
     Event.count(filter)
@@ -43,7 +49,7 @@ exports.get = function (opts, next) {
   });
 };
 
-exports.getOne = function (opts, next) {
+const getOne = function (opts, next) {
   Event.count(opts.params)
     .exec(function (err, count) {
       if (err) handleError(next, 'counting event', err);
@@ -58,7 +64,7 @@ exports.getOne = function (opts, next) {
     });
 };
 
-exports.create = {
+const create = {
   validate: {
     payload: {
       identifiers: [Joi.string()],
@@ -96,7 +102,7 @@ exports.create = {
       modified_date: new Date()
     };
 
-    var event = new Event(lodash.merge(req.payload, params));
+    var event = new Event(_.merge(req.payload, params));
 
     return event.save()
       .then(function (e) {
@@ -109,7 +115,28 @@ exports.create = {
   }
 };
 
+const createProximityFilter = function (fieldName, coord, maxDistance) {
+  const filter = {};
+  if (fieldName && coord && maxDistance) {
+    filter[fieldName] = {
+      $near: {
+        $geometry: {
+          type: 'Point',
+          coordinates: [coord[0], coord[1]]
+        },
+        $maxDistance: maxDistance
+      }
+    };
+  }
+  return filter;
+};
+
 const handleError = function (next, str, err) {
   console.log(str, err);
   next(err);
 };
+
+exports.create = create;
+exports.createProximityFilter = createProximityFilter;
+exports.get = get;
+exports.getOne = getOne;

--- a/test/lib/odata.js
+++ b/test/lib/odata.js
@@ -3,28 +3,35 @@ const Lab = require('lab');
 const lab = exports.lab = Lab.script();
 const ODATA = require('../../lib/odata');
 
-lab.test('event.createOrderBy undefined', (done) => {
+lab.test('ODATA.createOrderBy undefined', (done) => {
   Code.expect(ODATA.createOrderBy(undefined)).to.equal([]);
   done();
 });
 
-lab.test('event.createOrderBy single value', (done) => {
+lab.test('ODATA.createOrderBy single value', (done) => {
   Code.expect(ODATA.createOrderBy('a')).to.equal([['a', -1]]);
   done();
 });
 
-lab.test('event.createOrderBy multiple value', (done) => {
+lab.test('ODATA.createOrderBy multiple value', (done) => {
   Code.expect(ODATA.createOrderBy('a,b')).to.equal([['a', -1], ['b', -1]]);
   done();
 });
 
-lab.test('event.createOrderBy padding', (done) => {
+lab.test('ODATA.createOrderBy padding', (done) => {
   Code.expect(ODATA.createOrderBy('  a ,    b     ')).to.equal([['a', -1], ['b', -1]]);
   done();
 });
 
-lab.test('event.createOrderBy direction', (done) => {
+lab.test('ODATA.createOrderBy direction', (done) => {
   Code.expect(ODATA.createOrderBy('a,b asc')).to.equal([['a', -1], ['b', -1]]);
   Code.expect(ODATA.createOrderBy('a,b desc')).to.equal([['a', 1], ['b', 1]]);
+  done();
+});
+
+lab.test('ODATA.createFilter basics', (done) => {
+  Code.expect(ODATA.createFilter('a eq \'b\'')).to.equal({'a': 'b'});
+  Code.expect(ODATA.createFilter('a gt \'b\'')).to.equal({'a': {$gt: 'b'}});
+  Code.expect(ODATA.createFilter('contains(a, \'b\')')).to.equal({'a': /b/gi});
   done();
 });

--- a/test/routes/handlers/event.js
+++ b/test/routes/handlers/event.js
@@ -1,0 +1,20 @@
+const Code = require('code');
+const Lab = require('lab');
+const lab = exports.lab = Lab.script();
+const event = require('../../../routes/handlers/event');
+
+lab.test('event.createProximityFilter proximity under defined', (done) => {
+  Code.expect(event.createProximityFilter()).to.equal({});
+  Code.expect(event.createProximityFilter('a', undefined, undefined)).to.equal({});
+  Code.expect(event.createProximityFilter('a', [0, 1], undefined)).to.equal({});
+  Code.expect(event.createProximityFilter('a', undefined, 100)).to.equal({});
+  Code.expect(event.createProximityFilter(undefined, undefined, 100)).to.equal({});
+  done();
+});
+
+lab.test('event.createProximityFilter defined', (done) => {
+  Code.expect(event.createProximityFilter('a', [0, 1], 100)).to.equal(
+    {'a': {$near: {$geometry: {'coordinates': [0, 1], type: 'Point'}, $maxDistance: 100}}}
+  );
+  done();
+});


### PR DESCRIPTION
See readme for instructions. This is a purely long/lat based search with max determined by meters. Zipcode / city based searches can be discussed as additional functionality.

The coordinate specification is based on the mongodb conventions of long/lat, but can be switched if lat/long is more appropriate.

Maybe something like the following can be done client-side: https://www.npmjs.com/package/zipcodes

We could [do something server side](https://www.npmjs.com/package/node-geocoder), but may require URL changes to optionally query for city/zip/etc vs just long/lat