### PR TITLE
Fix lat long error when undefined

### DIFF
--- a/lib/facebook.js
+++ b/lib/facebook.js
@@ -69,6 +69,20 @@ module.exports.toOSDIEvent = function (facebookEvent) {
   if (facebookEvent.place && facebookEvent.place.location) {
     const facebookEventLocation = facebookEvent.place.location;
     const addressLines = facebookEventLocation.street ? [facebookEventLocation.street] : [];
+
+    var osdiLocation;
+    if (facebookEventLocation.longitude && facebookEventLocation.latitude) {
+      osdiLocation = {
+        longitude: facebookEventLocation.longitude,
+        latitude: facebookEventLocation.latitude,
+        type: 'Point',
+        coordinates: [
+          facebookEventLocation.longitude,
+          facebookEventLocation.latitude
+        ]
+      };
+    }
+
     location = {
       identifiers: [identifier],
       origin_system: originSystem,
@@ -78,15 +92,7 @@ module.exports.toOSDIEvent = function (facebookEvent) {
       region: facebookEventLocation.state,
       postal_code: facebookEventLocation.zip,
       country: facebookEventLocation.country,
-      location: {
-        longitude: facebookEventLocation.longitude,
-        latitude: facebookEventLocation.latitude,
-        type: 'Point',
-        coordinates: [
-          facebookEventLocation.longitude,
-          facebookEventLocation.latitude
-        ]
-      }
+      location: osdiLocation
     };
   }
 

--- a/test/lib/facebook.js
+++ b/test/lib/facebook.js
@@ -18,3 +18,23 @@ lab.test('Facebook.toOSDIEvent status', (done) => {
   Code.expect(Facebook.toOSDIEvent({is_canceled: true}).status).to.equal('cancelled');
   done();
 });
+
+lab.test('Facebook.toOSDIEvent location', (done) => {
+  const noLat = {location: {latitude: undefined, longitude: -122.42118}};
+  Code.expect(Facebook.toOSDIEvent({id: '00000', place: noLat}).location.location).to.equal(undefined);
+
+  const noLong = {location: {latitude: 37.76056, longitude: undefined}};
+  Code.expect(Facebook.toOSDIEvent({id: '00000', place: noLong}).location.location).to.equal(undefined);
+
+  const latLong = {location: {latitude: 37.76056, longitude: -122.42118}};
+  Code.expect(Facebook.toOSDIEvent({id: '00000', place: latLong}).location.location).to.equal({
+    longitude: -122.42118,
+    latitude: 37.76056,
+    type: 'Point',
+    coordinates: [
+      -122.42118,
+      37.76056
+    ]
+  });
+  done();
+});


### PR DESCRIPTION
There was some spurious errors when the lat/long was undefined from facebook which this issue should help with

```
 upserting [facebook:817942505015072] { MongoError: Can't extract geo keys: { _id: ObjectId('59d00284245c2867c0af362d'), identifiers: [ "facebook:817942505015072" ], __v: 0, created_date: new Date(1515037287955), modified_date: new Date(1515037287955), timezone: "America/Chicago", location: { location: { coordinates: [ null, null ], type: "Point", latitude: null, longitude: null }, ...
```