### PR TITLE
Organization whitelist for direct ETL

### DIFF
--- a/jobs/facebook-etl.js
+++ b/jobs/facebook-etl.js
@@ -20,7 +20,6 @@ const importEvents = function (job, done) {
     console.log(`${res.length} events downloaded`);
     const facebookEventIds = [];
     const makeRequest = function (facebookEvent, callback) {
-      console.log(facebookEvent.start_time + ', ' + facebookEvent.end_time);
       cacheFacebookEventImage(facebookEvent, function (err, imageUrl) {
         if (err) handleError(err, 'updating image for facebook event');
         if (facebookEvent.cover) {

--- a/jobs/facebook-etl.js
+++ b/jobs/facebook-etl.js
@@ -7,10 +7,17 @@ const ONE_DAY = 24 * 60 * 60 * 1000;
 
 require('../lib/database'); // Has side effect of connecting to database
 
+const sources = require('../resource/source.json');
+
 const importEvents = function (job, done) {
   console.log(`Facebook ETL Starting`);
 
-  Facebook.getAllFacebookEvents('resistance-calendar', function (err, res) {
+  const getAllFacebookEvents = function (user, callback, pages) {
+    console.log(`Getting events for ${user}`);
+    Facebook.getAllFacebookEvents(user, callback, pages);
+  };
+
+  async.concatLimit(sources['facebook'], 1, getAllFacebookEvents, function (err, res) {
     if (err) handleError(err, 'fetching facebook events');
     const facebookEventIds = [];
     const makeRequest = function (facebookEvent, callback) {

--- a/jobs/facebook-etl.js
+++ b/jobs/facebook-etl.js
@@ -19,6 +19,7 @@ const importEvents = function (job, done) {
 
   async.concatLimit(sources['facebook'], 1, getAllFacebookEvents, function (err, res) {
     if (err) handleError(err, 'fetching facebook events');
+    console.log(`${res.length} events downloaded`);
     const facebookEventIds = [];
     const makeRequest = function (facebookEvent, callback) {
       cacheFacebookEventImage(facebookEvent, function (err, imageUrl) {
@@ -46,6 +47,7 @@ const importEvents = function (job, done) {
       // Events without dates should I guess always be updated for now
       return !eventEndDatePadded || now < eventEndDatePadded;
     });
+    console.log(`${res.length} events to update`);
 
     // Avoid overwhelming any service by limiting parallelism
     async.eachLimit(eventsToUpdate, 5, makeRequest, function (err) {

--- a/lib/facebook.js
+++ b/lib/facebook.js
@@ -72,6 +72,20 @@ module.exports.toOSDIEvent = function (facebookEvent) {
   if (facebookEvent.place && facebookEvent.place.location) {
     const facebookEventLocation = facebookEvent.place.location;
     const addressLines = facebookEventLocation.street ? [facebookEventLocation.street] : [];
+
+    var osdiLocation;
+    if (facebookEventLocation.longitude && facebookEventLocation.latitude) {
+      osdiLocation = {
+        longitude: facebookEventLocation.longitude,
+        latitude: facebookEventLocation.latitude,
+        type: 'Point',
+        coordinates: [
+          facebookEventLocation.longitude,
+          facebookEventLocation.latitude
+        ]
+      };
+    }
+
     location = {
       identifiers: [identifier],
       origin_system: originSystem,
@@ -81,15 +95,7 @@ module.exports.toOSDIEvent = function (facebookEvent) {
       region: facebookEventLocation.state,
       postal_code: facebookEventLocation.zip,
       country: facebookEventLocation.country,
-      location: {
-        longitude: facebookEventLocation.longitude,
-        latitude: facebookEventLocation.latitude,
-        type: 'Point',
-        coordinates: [
-          facebookEventLocation.longitude,
-          facebookEventLocation.latitude
-        ]
-      }
+      location: osdiLocation
     };
   }
 

--- a/lib/facebook.js
+++ b/lib/facebook.js
@@ -27,12 +27,12 @@ FB.setAccessToken(process.env.FB_GRAPH_API_TOKEN);
  * This may be used in conjunction with toOSDIEvent to convert the results into
  * OSDI via the following example:
  *
- * getAllFacebookEvents(function (err, res) {
+ * getAllFacebookEvents('user', function (err, res) {
  *   if (err) return callback(err);
  *     callback(err, res.map(module.exports.toOSDIEvent));
  *   });
  */
-module.exports.getAllFacebookEvents = function (facebookUser, callback, pages) {
+module.exports.getAllFacebookEvents = function (user, callback, pages) {
   const queryParams = {
     fields: FB_EVENT_FIELDS_STRING,
     limit: 500
@@ -41,7 +41,10 @@ module.exports.getAllFacebookEvents = function (facebookUser, callback, pages) {
   const allFacebookEvents = [];
   const getAllEvents = function (query) {
     FB.get(query, queryParams, function (err, res) {
-      if (err) return callback(err);
+      if (err) {
+        // no fatal exceptions sent to callback
+        console.error(err.message);
+      }
       try {
         const facebookEvents = res.data;
         allFacebookEvents.push.apply(allFacebookEvents, facebookEvents);
@@ -58,7 +61,7 @@ module.exports.getAllFacebookEvents = function (facebookUser, callback, pages) {
     });
   };
 
-  getAllEvents(`${facebookUser}/events`);
+  getAllEvents(`${user}/events`);
 };
 
 module.exports.toOSDIEvent = function (facebookEvent) {
@@ -69,20 +72,6 @@ module.exports.toOSDIEvent = function (facebookEvent) {
   if (facebookEvent.place && facebookEvent.place.location) {
     const facebookEventLocation = facebookEvent.place.location;
     const addressLines = facebookEventLocation.street ? [facebookEventLocation.street] : [];
-
-    var osdiLocation;
-    if (facebookEventLocation.longitude && facebookEventLocation.latitude) {
-      osdiLocation = {
-        longitude: facebookEventLocation.longitude,
-        latitude: facebookEventLocation.latitude,
-        type: 'Point',
-        coordinates: [
-          facebookEventLocation.longitude,
-          facebookEventLocation.latitude
-        ]
-      };
-    }
-
     location = {
       identifiers: [identifier],
       origin_system: originSystem,
@@ -92,7 +81,15 @@ module.exports.toOSDIEvent = function (facebookEvent) {
       region: facebookEventLocation.state,
       postal_code: facebookEventLocation.zip,
       country: facebookEventLocation.country,
-      location: osdiLocation
+      location: {
+        longitude: facebookEventLocation.longitude,
+        latitude: facebookEventLocation.latitude,
+        type: 'Point',
+        coordinates: [
+          facebookEventLocation.longitude,
+          facebookEventLocation.latitude
+        ]
+      }
     };
   }
 

--- a/resource/source.json
+++ b/resource/source.json
@@ -1,7 +1,5 @@
 {
   "facebook": [
-    "IndivisibleSF",
-    "BerkeleyIndivisible",
-    "resistance-calendar"
+    "ActionNC"
   ]
 }

--- a/resource/source.json
+++ b/resource/source.json
@@ -1,0 +1,7 @@
+{
+  "facebook": [
+    "IndivisibleSF",
+    "BerkeleyIndivisible",
+    "resistance-calendar"
+  ]
+}

--- a/resource/source.json
+++ b/resource/source.json
@@ -1,5 +1,6 @@
 {
   "facebook": [
-    "ActionNC"
+    "IndivisibleSF",
+    "resistance-calendar"
   ]
 }

--- a/test/lib/facebook.js
+++ b/test/lib/facebook.js
@@ -20,21 +20,30 @@ lab.test('Facebook.toOSDIEvent status', (done) => {
 });
 
 lab.test('Facebook.toOSDIEvent location', (done) => {
-  const noLat = {location: {latitude: undefined, longitude: -122.42118}};
-  Code.expect(Facebook.toOSDIEvent({id: '00000', place: noLat}).location.location).to.equal(undefined);
+  Code.expect(Facebook.toOSDIEvent({id: '00000', place: {location: {}}}).location.location)
+    .to.equal(undefined);
 
-  const noLong = {location: {latitude: 37.76056, longitude: undefined}};
-  Code.expect(Facebook.toOSDIEvent({id: '00000', place: noLong}).location.location).to.equal(undefined);
+  Code.expect(Facebook.toOSDIEvent({id: '00000', place: {location: {latitude: undefined, longitude: -122.42118}}}).location.location)
+    .to.equal(undefined);
 
-  const latLong = {location: {latitude: 37.76056, longitude: -122.42118}};
-  Code.expect(Facebook.toOSDIEvent({id: '00000', place: latLong}).location.location).to.equal({
-    longitude: -122.42118,
-    latitude: 37.76056,
-    type: 'Point',
-    coordinates: [
-      -122.42118,
-      37.76056
-    ]
-  });
+  Code.expect(Facebook.toOSDIEvent({id: '00000', place: {location: {latitude: null, longitude: -122.42118}}}).location.location)
+    .to.equal(undefined);
+
+  Code.expect(Facebook.toOSDIEvent({id: '00000', place: {location: {latitude: 37.76056, longitude: undefined}}}).location.location)
+    .to.equal(undefined);
+
+  Code.expect(Facebook.toOSDIEvent({id: '00000', place: {location: {latitude: 37.76056, longitude: null}}}).location.location)
+    .to.equal(undefined);
+
+  Code.expect(Facebook.toOSDIEvent({id: '00000', place: {location: {latitude: 37.76056, longitude: -122.42118}}}).location.location)
+    .to.equal({
+      longitude: -122.42118,
+      latitude: 37.76056,
+      type: 'Point',
+      coordinates: [
+        -122.42118,
+        37.76056
+      ]
+    });
   done();
 });


### PR DESCRIPTION
Expands the list of organizations from resistence-calendar to a configurable json in order to whitelist "class a" organizations for direct ETL into RC database.