### PR TITLE
Break out event filter by date and add tests

### DIFF
--- a/config.js
+++ b/config.js
@@ -3,7 +3,7 @@ module.exports = {
   maxPageSize: process.env.MAX_PAGE_SIZE || 25,
   mongoUri: process.env.MONGODB_URI || 'mongodb://127.0.0.1:27017/rc_test',
   s3ImageBucket: process.env.S3_BUCKET_NAME,
-  eventTimeToLiveMs: 30 * 24 * 60 * 60 * 1000,
+  eventTimeToLiveMs: 90 * 24 * 60 * 60 * 1000,
   facebookGraphApiVersion: process.env.FB_GRAPH_API_VERSION || '2.8',
   facebookGraphApiToken: process.env.FB_GRAPH_API_TOKEN
 };

--- a/config.js
+++ b/config.js
@@ -2,5 +2,8 @@ module.exports = {
   baseUrl: process.env.BASE_URL || 'http://localhost:8000',
   maxPageSize: process.env.MAX_PAGE_SIZE || 25,
   mongoUri: process.env.MONGODB_URI || 'mongodb://127.0.0.1:27017/rc_test',
-  s3ImageBucket: process.env.S3_BUCKET_NAME
+  s3ImageBucket: process.env.S3_BUCKET_NAME,
+  eventTimeToLiveMs: 30 * 24 * 60 * 60 * 1000,
+  facebookGraphApiVersion: process.env.FB_GRAPH_API_VERSION || '2.8',
+  facebookGraphApiToken: process.env.FB_GRAPH_API_TOKEN
 };

--- a/lib/facebook.js
+++ b/lib/facebook.js
@@ -61,6 +61,18 @@ module.exports.getAllFacebookEvents = function (facebookUser, callback, pages) {
   getAllEvents(`${facebookUser}/events`);
 };
 
+const THIRTY_DAYS = 30 * 24 * 60 * 60 * 1000;
+module.exports.filterEventsAfter = function (date, facebookEvents) {
+  return facebookEvents.filter(function (facebookEvent) {
+    const eventAnchorDateString = facebookEvent.end_time ? facebookEvent.end_time : facebookEvent.start_time;
+    const eventAnchorDate = eventAnchorDateString ? new Date(eventAnchorDateString) : undefined;
+    const eventEndDatePadded = eventAnchorDate ? (eventAnchorDate.getTime() + THIRTY_DAYS) : undefined;
+
+    // Events without dates should I guess always be updated for now
+    return !eventEndDatePadded || (date.getTime() < eventEndDatePadded);
+  });
+};
+
 module.exports.toOSDIEvent = function (facebookEvent) {
   const identifier = `facebook:${facebookEvent.id}`;
   const originSystem = 'Facebook';

--- a/lib/facebook.js
+++ b/lib/facebook.js
@@ -2,6 +2,7 @@
 
 const FB = require('fbgraph');
 const Event = require('../models/osdi/event');
+const config = require('../config.js');
 
 const FB_EVENT_FIELDS_STRING = [
   'attending_count',
@@ -18,8 +19,8 @@ const FB_EVENT_FIELDS_STRING = [
   'timezone'
 ].join(',');
 
-FB.setVersion(process.env.FB_GRAPH_API_VERSION || '2.8');
-FB.setAccessToken(process.env.FB_GRAPH_API_TOKEN);
+FB.setVersion(config.facebookGraphApiVersion);
+FB.setAccessToken(config.facebookGraphApiToken);
 
 /**
  * WARNING: Useful only for bulk imports and not intended for general querying.
@@ -61,12 +62,11 @@ module.exports.getAllFacebookEvents = function (facebookUser, callback, pages) {
   getAllEvents(`${facebookUser}/events`);
 };
 
-const THIRTY_DAYS = 30 * 24 * 60 * 60 * 1000;
 module.exports.filterEventsAfter = function (date, facebookEvents) {
   return facebookEvents.filter(function (facebookEvent) {
     const eventAnchorDateString = facebookEvent.end_time ? facebookEvent.end_time : facebookEvent.start_time;
     const eventAnchorDate = eventAnchorDateString ? new Date(eventAnchorDateString) : undefined;
-    const eventEndDatePadded = eventAnchorDate ? (eventAnchorDate.getTime() + THIRTY_DAYS) : undefined;
+    const eventEndDatePadded = eventAnchorDate ? (eventAnchorDate.getTime() + config.eventTimeToLiveMs) : undefined;
 
     // Events without dates should I guess always be updated for now
     return !eventEndDatePadded || (date.getTime() < eventEndDatePadded);

--- a/test/lib/facebook.js
+++ b/test/lib/facebook.js
@@ -38,3 +38,26 @@ lab.test('Facebook.toOSDIEvent location', (done) => {
   });
   done();
 });
+
+lab.test('Facebook.filterEventsAfter works without date', (done) => {
+  const now = new Date();
+  const events = [{id: '00000'}];
+  Code.expect(Facebook.filterEventsAfter(now, events)).to.equal(events);
+  done();
+});
+
+lab.test('Facebook.filterEventsAfter works with dates after padded date', (done) => {
+  const now = new Date();
+  const later = new Date(now.getTime() - ((30 * 24 * 60 * 60 * 1000) - 1));
+  const events = [{id: '00000', end_time: later}, {id: '00000', start_time: later}];
+  Code.expect(Facebook.filterEventsAfter(now, events)).to.equal(events);
+  done();
+});
+
+lab.test('Facebook.filterEventsAfter works with dates before padded date', (done) => {
+  const now = new Date();
+  const beforeNow = new Date(now.getTime() - ((30 * 24 * 60 * 60 * 1000) + 1));
+  const events = [{id: '00000', end_time: beforeNow}, {id: '00000', start_time: beforeNow}];
+  Code.expect(Facebook.filterEventsAfter(now, events)).to.equal([]);
+  done();
+});

--- a/test/lib/facebook.js
+++ b/test/lib/facebook.js
@@ -2,6 +2,7 @@ const Code = require('code');
 const Lab = require('lab');
 const lab = exports.lab = Lab.script();
 const Facebook = require('../../lib/facebook');
+const config = require('../../config.js');
 
 lab.test('Facebook.toOSDIEvent identifiers', (done) => {
   const osdiEvent = Facebook.toOSDIEvent({
@@ -48,7 +49,7 @@ lab.test('Facebook.filterEventsAfter works without date', (done) => {
 
 lab.test('Facebook.filterEventsAfter works with dates after padded date', (done) => {
   const now = new Date();
-  const later = new Date(now.getTime() - ((30 * 24 * 60 * 60 * 1000) - 1));
+  const later = new Date(now.getTime() - (config.eventTimeToLiveMs - 1));
   const events = [{id: '00000', end_time: later}, {id: '00000', start_time: later}];
   Code.expect(Facebook.filterEventsAfter(now, events)).to.equal(events);
   done();
@@ -56,7 +57,7 @@ lab.test('Facebook.filterEventsAfter works with dates after padded date', (done)
 
 lab.test('Facebook.filterEventsAfter works with dates before padded date', (done) => {
   const now = new Date();
-  const beforeNow = new Date(now.getTime() - ((30 * 24 * 60 * 60 * 1000) + 1));
+  const beforeNow = new Date(now.getTime() - (config.eventTimeToLiveMs + 1));
   const events = [{id: '00000', end_time: beforeNow}, {id: '00000', start_time: beforeNow}];
   Code.expect(Facebook.filterEventsAfter(now, events)).to.equal([]);
   done();


### PR DESCRIPTION
This was erroneous and causing a lot of unnecessary updates and preventing events from being purged.