### PR TITLE
Enable address parsing to replace missing information

### DIFF
--- a/jobs/facebook-etl.js
+++ b/jobs/facebook-etl.js
@@ -1,5 +1,6 @@
 const Event = require('../models/osdi/event');
 const Facebook = require('../lib/facebook');
+const Geo = require('../lib/geo');
 const async = require('async');
 const image = require('../lib/image');
 const request = require('request');
@@ -42,14 +43,31 @@ const importEvents = function (job, done) {
         if (facebookEvent.cover) {
           facebookEvent.cover.source = imageUrl;
         }
+
         const osdiEvent = Facebook.toOSDIEvent(facebookEvent);
         facebookEventIds.push(facebookEvent.id);
         const facebookEventName = `[facebook:${facebookEvent.id}]`;
-        upsertOSDIEvent(osdiEvent, function (err, savedEvent) {
-          if (err) handleError(err, `upserting ${facebookEventName}`);
-          console.log(`upserted ${facebookEventName} - ${savedEvent._id}`);
-          callback();
-        });
+
+        if (!osdiEvent.location && facebookEvent.place && facebookEvent.place.name) {
+          Geo.parseAddressStringToOSDILocation(facebookEvent.place.name, function (err, osdiLocation) {
+            if (err) handleError(err, `converting address to OSDI location for ${facebookEventName}`);
+            if (osdiLocation) {
+              osdiEvent.location = osdiLocation;
+            }
+
+            upsertOSDIEvent(osdiEvent, function (err, savedEvent) {
+              if (err) handleError(err, `upserting ${facebookEventName}`);
+              console.log(`upserted ${facebookEventName} - ${savedEvent._id}`);
+              callback();
+            });
+          });
+        } else {
+          upsertOSDIEvent(osdiEvent, function (err, savedEvent) {
+            if (err) handleError(err, `upserting ${facebookEventName}`);
+            console.log(`upserted ${facebookEventName} - ${savedEvent._id}`);
+            callback();
+          });
+        }
       });
     };
 

--- a/jobs/facebook-etl.js
+++ b/jobs/facebook-etl.js
@@ -46,28 +46,17 @@ const importEvents = function (job, done) {
 
         const osdiEvent = Facebook.toOSDIEvent(facebookEvent);
         facebookEventIds.push(facebookEvent.id);
-        const facebookEventName = `[facebook:${facebookEvent.id}]`;
 
-        if (!osdiEvent.location && facebookEvent.place && facebookEvent.place.name) {
-          Geo.parseAddressStringToOSDILocation(facebookEvent.place.name, function (err, osdiLocation) {
-            if (err) handleError(err, `converting address to OSDI location for ${facebookEventName}`);
-            if (osdiLocation) {
-              osdiEvent.location = osdiLocation;
-            }
+        fixFacebookAddress(facebookEvent, osdiEvent, function (err, osdiEvent) {
+          const facebookEventId = `[facebook:${facebookEvent.id}]`;
 
-            upsertOSDIEvent(osdiEvent, function (err, savedEvent) {
-              if (err) handleError(err, `upserting ${facebookEventName}`);
-              console.log(`upserted ${facebookEventName} - ${savedEvent._id}`);
-              callback();
-            });
-          });
-        } else {
+          if (err) handleError(err, `converting address to OSDI location for ${facebookEventId}`);
           upsertOSDIEvent(osdiEvent, function (err, savedEvent) {
-            if (err) handleError(err, `upserting ${facebookEventName}`);
-            console.log(`upserted ${facebookEventName} - ${savedEvent._id}`);
+            if (err) handleError(err, `upserting ${facebookEventId}`);
+            console.log(`upserted ${facebookEventId} - ${savedEvent._id}`);
             callback();
           });
-        }
+        });
       });
     };
 
@@ -146,6 +135,20 @@ const cacheFacebookEventImage = function (facebookEvent, callback) {
   } else {
     console.log(`${facebookEventId} has no image`);
     callback(null, undefined);
+  }
+};
+
+const fixFacebookAddress = function (facebookEvent, osdiEvent, callback) {
+  if (!osdiEvent.location && facebookEvent.place && facebookEvent.place.name) {
+    Geo.parseAddressStringToOSDILocation(facebookEvent.place.name, function (err, osdiLocation) {
+      if (err) callback(err);
+      if (osdiLocation) {
+        osdiEvent.location = osdiLocation;
+      }
+      callback(null, osdiEvent);
+    });
+  } else {
+    callback(null, osdiEvent);
   }
 };
 

--- a/lib/geo.js
+++ b/lib/geo.js
@@ -1,5 +1,6 @@
 const cities = require('cities');
 const allCities = require('all-the-cities');
+const parseAddress = require('parse-address-string');
 const _ = require('lodash');
 
 module.exports = {
@@ -24,5 +25,41 @@ module.exports = {
         parseFloat(response[0].lat)
       ];
     } else return null;
+  },
+
+  parseAddressStringToOSDILocation: function (addressString, callback) {
+    parseAddress(addressString, function (err, addressObj) {
+      if (err) return callback(err);
+      if (!addressObj) return callback(null, undefined);
+
+      const coords = cities.zip_lookup(addressObj.postal_code);
+
+      console.log(JSON.stringify(addressObj));
+      console.log(JSON.stringify(coords));
+
+      const coordinatLocation = coords ? {
+        longitude: parseFloat(coords.longitude),
+        latitude: parseFloat(coords.latitude),
+        type: 'Point',
+        coordinates: [
+          parseFloat(coords.longitude),
+          parseFloat(coords.latitude)
+        ]
+      } : undefined;
+
+      const osdiLocation = {
+        // identifiers
+        // origin_system
+        // venue
+        address_lines: [addressObj.street_address1],
+        locality: addressObj.city,
+        region: addressObj.state,
+        postal_code: addressObj.postal_code,
+        country: addressObj.country,
+        location: coordinatLocation
+      };
+
+      callback(null, osdiLocation);
+    });
   }
 };

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "hapi-cors-headers": "1.0.0",
     "joi": "^10.2.2",
     "lodash": "^4.17.4",
+    "parse-address-string": "0.0.3",
     "mockgoose": "5.3.3",
     "moment": "2.18.0",
     "moment-timezone": "0.5.13",

--- a/test/lib/geo.js
+++ b/test/lib/geo.js
@@ -1,0 +1,21 @@
+const Code = require('code');
+const Lab = require('lab');
+const lab = exports.lab = Lab.script();
+const Geo = require('../../lib/geo');
+
+lab.test('Geo.parseAddressStringToOSDILocation', (done) => {
+  const addressLine = 'Bryant Park, 100 S Gulfview Rd, S Lake Worth, FL 33460';
+  Geo.parseAddressStringToOSDILocation(addressLine, function (err, osdiLocation) {
+    if (err) Code.fail(err);
+
+    Code.expect(osdiLocation.location.type, 'Point');
+    Code.expect(osdiLocation.location.latitude).to.equal(26.619695);
+    Code.expect(osdiLocation.location.longitude).to.equal(-80.05676);
+    Code.expect(osdiLocation.location.coordinates).to.equal([-80.05676, 26.619695]);
+
+    Code.expect(osdiLocation.postal_code).to.equal('33460');
+    Code.expect(osdiLocation.region).to.equal('FL');
+    Code.expect(osdiLocation.address_lines[0]).to.equal('100 S Gulfview Rd');
+    done();
+  });
+});


### PR DESCRIPTION
In order to fill in incomplete details of events, we can parse the address line to fill out more metadata from a single address line, as well as do a lat/long lookup from the zipcode.
